### PR TITLE
Refactor Grid initialization to accept external board

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -5,19 +5,9 @@ pygame.font.init()
 
 
 class Grid:
-    board = [
-        [7, 8, 0, 4, 0, 0, 1, 2, 0],
-        [6, 0, 0, 0, 7, 5, 0, 0, 9],
-        [0, 0, 0, 6, 0, 1, 0, 7, 8],
-        [0, 0, 7, 0, 4, 0, 2, 6, 0],
-        [0, 0, 1, 0, 5, 0, 9, 3, 0],
-        [9, 0, 4, 0, 6, 0, 0, 0, 5],
-        [0, 7, 0, 3, 0, 0, 0, 1, 2],
-        [1, 2, 0, 0, 0, 7, 4, 0, 0],
-        [0, 4, 9, 2, 0, 6, 0, 0, 7]
-    ]
 
-    def __init__(self, rows, cols, width, height, win):
+    def __init__(self, board, rows, cols, width, height, win):
+        self.board = board
         self.rows = rows
         self.cols = cols
         self.cubes = [[Cube(self.board[i][j], i, j, width, height) for j in range(cols)] for i in range(rows)]
@@ -257,7 +247,18 @@ def format_time(secs):
 def main():
     win = pygame.display.set_mode((540,600))
     pygame.display.set_caption("Sudoku")
-    board = Grid(9, 9, 540, 540, win)
+    board = [
+        [7, 8, 0, 4, 0, 0, 1, 2, 0],
+        [6, 0, 0, 0, 7, 5, 0, 0, 9],
+        [0, 0, 0, 6, 0, 1, 0, 7, 8],
+        [0, 0, 7, 0, 4, 0, 2, 6, 0],
+        [0, 0, 1, 0, 5, 0, 9, 3, 0],
+        [9, 0, 4, 0, 6, 0, 0, 0, 5],
+        [0, 7, 0, 3, 0, 0, 0, 1, 2],
+        [1, 2, 0, 0, 0, 7, 4, 0, 0],
+        [0, 4, 9, 2, 0, 6, 0, 0, 7]
+    ]
+    board = Grid(board, 9, 9, 540, 540, win)
     key = None
     run = True
     start = time.time()


### PR DESCRIPTION
## Summary
- Allow `Grid` to be constructed with an external board, eliminating the previous class-level board definition.
- Update `main()` to provide the board when creating a `Grid` instance.

## Testing
- `python -m py_compile GUI.py`
- `python -m py_compile solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae4ea0dfec832d93c791e6b9738aeb